### PR TITLE
Add redis support for Papermerge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ ARG RUNTIME_PACKAGES="\
 	python3-cryptography \
 	python3-distutils \
 	python3-setuptools \
+	redis \
 	tesseract-ocr \
 	tesseract-ocr-eng \
 	uwsgi \
@@ -70,7 +71,8 @@ RUN \
 	$BUILD_PACKAGES && \
  rm -rf \
 	/root/.cache \
-	/tmp/*
+	/tmp/* && \
+ apt-get clean -y
 
 # copy local files
 COPY root/ /

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -33,6 +33,7 @@ ARG RUNTIME_PACKAGES="\
 	python3-cryptography \
 	python3-distutils \
 	python3-setuptools \
+	redis \
 	tesseract-ocr \
 	tesseract-ocr-eng \
 	uwsgi \
@@ -70,7 +71,8 @@ RUN \
 	$BUILD_PACKAGES && \
  rm -rf \
 	/root/.cache \
-	/tmp/*
+	/tmp/* && \
+ apt-get clean -y
 
 # copy local files
 COPY root/ /

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -33,6 +33,7 @@ ARG RUNTIME_PACKAGES="\
 	python3-cryptography \
 	python3-distutils \
 	python3-setuptools \
+	redis \
 	tesseract-ocr \
 	tesseract-ocr-eng \
 	uwsgi \
@@ -70,7 +71,8 @@ RUN \
 	$BUILD_PACKAGES && \
  rm -rf \
 	/root/.cache \
-	/tmp/*
+	/tmp/* && \
+ apt-get clean -y
 
 # copy local files
 COPY root/ /

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -28,6 +28,7 @@ param_ports:
 param_usage_include_env: true
 param_env_vars:
   - { env_var: "TZ", env_value: "America/New_York", desc: "Specify a timezone to use EG America/New_York"}
+  - { env_var: "REDIS_URL", env_value: "papermerge-redis", desc: "Specify an exteral redis instance to use. Can include a port and/or db."}
 
 # optional parameters
 optional_block_1: false
@@ -40,5 +41,6 @@ app_setup_block: |
   More info at [papermerge]({{ project_url }}).
 # changelog
 changelogs:
+  - { date: "01.02.21:", desc: "Add redis." }  
   - { date: "09.12.20:", desc: "Fix locales." }
   - { date: "08.08.20:", desc: "Initial Release." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -30,7 +30,7 @@ param_env_vars:
   - { env_var: "TZ", env_value: "America/New_York", desc: "Specify a timezone to use EG America/New_York"}
 opt_param_usage_include_env: true
 opt_param_env_vars:
-  - { env_var: "REDIS_URL", env_value: "papermerge-redis", desc: "Specify an exteral redis instance to use. Can include a port and/or db. If changed after initial setup also will require manual modification of /config/settings.py"}
+  - { env_var: "REDIS_URL", env_value: "papermerge-redis", desc: "Specify an exteral redis instance to use. Can include a port and/or db. If changed after initial setup will also require manual modification of /config/settings.py"}
 
 # optional parameters
 optional_block_1: false

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -28,6 +28,8 @@ param_ports:
 param_usage_include_env: true
 param_env_vars:
   - { env_var: "TZ", env_value: "America/New_York", desc: "Specify a timezone to use EG America/New_York"}
+opt_param_usage_include_env: true
+opt_param_env_vars:
   - { env_var: "REDIS_URL", env_value: "papermerge-redis", desc: "Specify an exteral redis instance to use. Can include a port and/or db."}
 
 # optional parameters

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -30,7 +30,7 @@ param_env_vars:
   - { env_var: "TZ", env_value: "America/New_York", desc: "Specify a timezone to use EG America/New_York"}
 opt_param_usage_include_env: true
 opt_param_env_vars:
-  - { env_var: "REDIS_URL", env_value: "papermerge-redis", desc: "Specify an exteral redis instance to use. Can include a port and/or db."}
+  - { env_var: "REDIS_URL", env_value: "papermerge-redis", desc: "Specify an exteral redis instance to use. Can include a port and/or db. If changed after initial setup also will require manual modification of /config/settings.py"}
 
 # optional parameters
 optional_block_1: false

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -30,7 +30,7 @@ param_env_vars:
   - { env_var: "TZ", env_value: "America/New_York", desc: "Specify a timezone to use EG America/New_York"}
 opt_param_usage_include_env: true
 opt_param_env_vars:
-  - { env_var: "REDIS_URL", env_value: "papermerge-redis", desc: "Specify an exteral redis instance to use. Can include a port and/or db. If changed after initial setup will also require manual modification of /config/settings.py"}
+  - { env_var: "REDIS_URL", env_value: "", desc: "Specify an external redis instance to use. Can optionally include a port (`redis:6379`) and/or db (`redis/foo`). If left blank or not included, will use a built-in redis instance. If changed after initial setup will also require manual modification of /config/settings.py"}
 
 # optional parameters
 optional_block_1: false

--- a/root/defaults/redis.conf
+++ b/root/defaults/redis.conf
@@ -1,0 +1,1 @@
+dir /redis

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -2,9 +2,12 @@
 
 export DJANGO_SETTINGS_MODULE=config.settings.production
 
-# remove services unless they're enabled
+# configure redis options
 if [[ -v "$REDIS_URL" ]]; then
     rm -rf /etc/services.d/redis
+    printf '%s\n' '' 'CELERY_BROKER_URL = "redis://$REDIS_URL"' 'CELERY_BROKER_TRANSPORT_OPTIONS = {}' 'CELERY_RESULT_BACKEND = "redis://$REDIS_URL/0"' >> /defaults/settings.py
+else
+    printf '%s\n' '' 'CELERY_BROKER_URL = "redis://localhost"' 'CELERY_BROKER_TRANSPORT_OPTIONS = {}' 'CELERY_RESULT_BACKEND = "redis://localhost/0"' >> /defaults/settings.py
 fi
 
 mkdir -p /data/{media,queue,static}

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -5,9 +5,9 @@ export DJANGO_SETTINGS_MODULE=config.settings.production
 # configure redis options
 if [[ -v "$REDIS_URL" ]]; then
     rm -rf /etc/services.d/redis
-    printf '%s\n' '' 'CELERY_BROKER_URL = "redis://$REDIS_URL"' 'CELERY_BROKER_TRANSPORT_OPTIONS = {}' 'CELERY_RESULT_BACKEND = "redis://$REDIS_URL/0"' >> /defaults/settings.py
+    printf '%s\n' '' 'CELERY_BROKER_URL = "redis://$REDIS_URL"' 'CELERY_BROKER_TRANSPORT_OPTIONS = {}' 'CELERY_RESULT_BACKEND = "redis://$REDIS_URL"' >> /defaults/settings.py
 else
-    printf '%s\n' '' 'CELERY_BROKER_URL = "redis://localhost"' 'CELERY_BROKER_TRANSPORT_OPTIONS = {}' 'CELERY_RESULT_BACKEND = "redis://localhost/0"' >> /defaults/settings.py
+    printf '%s\n' '' 'CELERY_BROKER_URL = "redis://localhost"' 'CELERY_BROKER_TRANSPORT_OPTIONS = {}' 'CELERY_RESULT_BACKEND = "redis://localhost"' >> /defaults/settings.py
 fi
 
 mkdir -p /data/{media,queue,static}

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -2,6 +2,11 @@
 
 export DJANGO_SETTINGS_MODULE=config.settings.production
 
+# remove services unless they're enabled
+if [[ -v "$REDIS_URL" ]]; then
+    rm -rf /etc/services.d/redis
+fi
+
 mkdir -p /data/{media,queue,static}
 
 if [ ! -f "/config/settings.py" ]; then

--- a/root/etc/services.d/redis/run
+++ b/root/etc/services.d/redis/run
@@ -1,8 +1,5 @@
 #!/usr/bin/with-contenv bash
 
-apt-get install -y \
-	redis
-
 mkdir -p /redis
 
 exec \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-papermerge/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Add redis support for Papermerge in the form of a local install of redis and a REDIS_URL env for external instances. Does not touch config on existing installs so will require user intervention to enable it.

## Benefits of this PR and context:
Without redis, papermerge CPU usage grows consistently over time due to poor performance of the file storage provider.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built and tested locally

## Source / References:
[https://github.com/ciur/papermerge/issues/198](https://github.com/ciur/papermerge/issues/198)
